### PR TITLE
Use https://libigl.github.io/ as base URL

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before opening an issue on creating a pull request, please check the following:
 
     - Make sure you read the information contained in the libigl
       [**homepage**](https://github.com/libigl/libigl) as well as the
-      [**tutorial**](http://libigl.github.io/libigl/tutorial).
+      [**tutorial**](https://libigl.github.io/libigl/tutorial).
 
 ## General Issues
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before opening an issue on creating a pull request, please check the following:
 
     - Make sure you read the information contained in the libigl
       [**homepage**](https://github.com/libigl/libigl) as well as the
-      [**tutorial**](https://libigl.github.io/libigl/tutorial).
+      [**tutorial**](https://libigl.github.io/tutorial).
 
 ## General Issues
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@
     It sounds like you're trying to compute a union. Are your two meshes closed, watertight manifolds? Then you could call `igl/boolean/mesh_boolean` with the union option. If not, then there's still hope with something else. _[Alec]_
 
 ??? faq "In other apps I have seen the the user is asked to specify singularities , and the then the rosy field is generated. But in libigl it seems like you have to specify faces and direction vectors to design a field. Is it possible to specify singularities?"
-    It is not possible to specify singularities right now. To specify the directions, the vectors should be in global coordinates (the vectors are 3D vectors, the libigl function takes care of projecting them onto the corresponding face), you can take a look here for a basic example that fixes only one face: [Example 505](http://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization) _[Daniele]_
+    It is not possible to specify singularities right now. To specify the directions, the vectors should be in global coordinates (the vectors are 3D vectors, the libigl function takes care of projecting them onto the corresponding face), you can take a look here for a basic example that fixes only one face: [Example 505](https://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization) _[Daniele]_
 
 ??? faq "Does Libigl use the same 2D Triangle code (my search in the Libigl source code indicates NO, but a confirmation would be reassuring)?"
     No, it uses CGAL for triangulation. _[Alec]_
@@ -13,11 +13,11 @@
     No, the dependency on CGAL would require severely rewriting a core function. It is possible to do, but I will not do it. _[Alec]_
 
 ??? faq "Do you have a ready to run command line program so that I can run a test with a few of my sample data sets?"
-    No, but it would be very easy to alter the [boolean tutorial example](http://libigl.github.io/libigl/tutorial/#boolean-operations-on-meshes) to do that. Basically drop the viewer and change the hardcoded paths to command line arguments and write out the result to an obj. _[Alec]_
+    No, but it would be very easy to alter the [boolean tutorial example](https://libigl.github.io/libigl/tutorial/#boolean-operations-on-meshes) to do that. Basically drop the viewer and change the hardcoded paths to command line arguments and write out the result to an obj. _[Alec]_
 
 ??? faq "I see that it can generate N-rosy fields, but is it possible to remesh based on the rosy field?"
     Here is an example that uses libigl to produce a seamless parametrization:
-    [Example 505](http://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization)
+    [Example 505](https://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization)
 
     If you want a mesh, you can pass this parametrization to libQEX ([https://github.com/hcebke/libQEx](https://github.com/hcebke/libQEx)) to extract it. We do not have it built in in the tutorial due to a more restrictive licence used by libQEx. _[Daniele]_
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@
     It sounds like you're trying to compute a union. Are your two meshes closed, watertight manifolds? Then you could call `igl/boolean/mesh_boolean` with the union option. If not, then there's still hope with something else. _[Alec]_
 
 ??? faq "In other apps I have seen the the user is asked to specify singularities , and the then the rosy field is generated. But in libigl it seems like you have to specify faces and direction vectors to design a field. Is it possible to specify singularities?"
-    It is not possible to specify singularities right now. To specify the directions, the vectors should be in global coordinates (the vectors are 3D vectors, the libigl function takes care of projecting them onto the corresponding face), you can take a look here for a basic example that fixes only one face: [Example 505](https://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization) _[Daniele]_
+    It is not possible to specify singularities right now. To specify the directions, the vectors should be in global coordinates (the vectors are 3D vectors, the libigl function takes care of projecting them onto the corresponding face), you can take a look here for a basic example that fixes only one face: [Example 505](https://libigl.github.io/tutorial/#global-seamless-integer-grid-parametrization) _[Daniele]_
 
 ??? faq "Does Libigl use the same 2D Triangle code (my search in the Libigl source code indicates NO, but a confirmation would be reassuring)?"
     No, it uses CGAL for triangulation. _[Alec]_
@@ -13,11 +13,11 @@
     No, the dependency on CGAL would require severely rewriting a core function. It is possible to do, but I will not do it. _[Alec]_
 
 ??? faq "Do you have a ready to run command line program so that I can run a test with a few of my sample data sets?"
-    No, but it would be very easy to alter the [boolean tutorial example](https://libigl.github.io/libigl/tutorial/#boolean-operations-on-meshes) to do that. Basically drop the viewer and change the hardcoded paths to command line arguments and write out the result to an obj. _[Alec]_
+    No, but it would be very easy to alter the [boolean tutorial example](https://libigl.github.io/tutorial/#boolean-operations-on-meshes) to do that. Basically drop the viewer and change the hardcoded paths to command line arguments and write out the result to an obj. _[Alec]_
 
 ??? faq "I see that it can generate N-rosy fields, but is it possible to remesh based on the rosy field?"
     Here is an example that uses libigl to produce a seamless parametrization:
-    [Example 505](https://libigl.github.io/libigl/tutorial/#global-seamless-integer-grid-parametrization)
+    [Example 505](https://libigl.github.io/tutorial/#global-seamless-integer-grid-parametrization)
 
     If you want a mesh, you can pass this parametrization to libQEX ([https://github.com/hcebke/libQEx](https://github.com/hcebke/libQEx)) to extract it. We do not have it built in in the tutorial due to a more restrictive licence used by libQEx. _[Daniele]_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ stored in an n-by-3 matrix of vertex positions `V` and an m-by-3 matrix of
 triangle indices `F`.
 
 _Optionally_ the library may also be
-[pre-compiled](https://libigl.github.io/libigl/static-library/) into a
+[pre-compiled](https://libigl.github.io/static-library/) into a
 statically linked library, for faster compile times with your projects. This
 only effects compile time (run-time performance and behavior is identical). If
 in doubt, use the header-only default mode: (i.e. just include the headers you
@@ -40,7 +40,7 @@ and Windows with Visual Studio 2015 Community Edition.
 ## Tutorial
 
 As of version 1.0, libigl includes an introductory
-[tutorial](https://libigl.github.io/libigl/tutorial) that covers many
+[tutorial](https://libigl.github.io/tutorial) that covers many
 functionalities.
 
 ## libigl Example Project
@@ -53,9 +53,9 @@ way of starting a new personal project using libigl.
 ## Coding Guidelines and Tips
 
 libigl follows strict coding guidelines, please take a look
-[here](https://libigl.github.io/libigl/style-guidelines) before submitting your
+[here](https://libigl.github.io/style-guidelines) before submitting your
 pull requests. We also have a set of [general coding
-tips](https://libigl.github.io/libigl/coding-guidelines) on how to code a
+tips](https://libigl.github.io/coding-guidelines) on how to code a
 geometry processing research project.
 
 ## Installation
@@ -108,7 +108,7 @@ Hello, mesh:
 Dependencies are on a per-include basis and the majority of the functions in
 libigl depends only on the [Eigen](http://eigen.tuxfamily.org) library.
 
-For more information see our [tutorial](https://libigl.github.io/libigl/tutorial).
+For more information see our [tutorial](https://libigl.github.io/tutorial).
 
 ### Optional Dependencies
 
@@ -198,7 +198,7 @@ for more information about unit testing in libigl.
 If you are interested in joining development, please fork the repository and
 submit a [pull request](https://help.github.com/articles/using-pull-requests/)
 with your changes. libigl follows strict coding guidelines, please take a look
-at our  [style guidelines](https://libigl.github.io/libigl/style-guidelines)
+at our  [style guidelines](https://libigl.github.io/style-guidelines)
 before submitting your pull requests.
 
 ## License
@@ -218,7 +218,7 @@ BibTeX entry:
 @misc{libigl,
   title = {{libigl}: A simple {C++} geometry processing library},
   author = {Alec Jacobson and Daniele Panozzo and others},
-  note = {https://libigl.github.io/libigl/},
+  note = {https://libigl.github.io/},
   year = {2018},
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ stored in an n-by-3 matrix of vertex positions `V` and an m-by-3 matrix of
 triangle indices `F`.
 
 _Optionally_ the library may also be
-[pre-compiled](http://libigl.github.io/libigl/static-library/) into a
+[pre-compiled](https://libigl.github.io/libigl/static-library/) into a
 statically linked library, for faster compile times with your projects. This
 only effects compile time (run-time performance and behavior is identical). If
 in doubt, use the header-only default mode: (i.e. just include the headers you
@@ -40,7 +40,7 @@ and Windows with Visual Studio 2015 Community Edition.
 ## Tutorial
 
 As of version 1.0, libigl includes an introductory
-[tutorial](http://libigl.github.io/libigl/tutorial) that covers many
+[tutorial](https://libigl.github.io/libigl/tutorial) that covers many
 functionalities.
 
 ## libigl Example Project
@@ -53,9 +53,9 @@ way of starting a new personal project using libigl.
 ## Coding Guidelines and Tips
 
 libigl follows strict coding guidelines, please take a look
-[here](http://libigl.github.io/libigl/style-guidelines) before submitting your
+[here](https://libigl.github.io/libigl/style-guidelines) before submitting your
 pull requests. We also have a set of [general coding
-tips](http://libigl.github.io/libigl/coding-guidelines) on how to code a
+tips](https://libigl.github.io/libigl/coding-guidelines) on how to code a
 geometry processing research project.
 
 ## Installation
@@ -108,7 +108,7 @@ Hello, mesh:
 Dependencies are on a per-include basis and the majority of the functions in
 libigl depends only on the [Eigen](http://eigen.tuxfamily.org) library.
 
-For more information see our [tutorial](http://libigl.github.io/libigl/tutorial).
+For more information see our [tutorial](https://libigl.github.io/libigl/tutorial).
 
 ### Optional Dependencies
 
@@ -198,7 +198,7 @@ for more information about unit testing in libigl.
 If you are interested in joining development, please fork the repository and
 submit a [pull request](https://help.github.com/articles/using-pull-requests/)
 with your changes. libigl follows strict coding guidelines, please take a look
-at our  [style guidelines](http://libigl.github.io/libigl/style-guidelines)
+at our  [style guidelines](https://libigl.github.io/libigl/style-guidelines)
 before submitting your pull requests.
 
 ## License
@@ -218,7 +218,7 @@ BibTeX entry:
 @misc{libigl,
   title = {{libigl}: A simple {C++} geometry processing library},
   author = {Alec Jacobson and Daniele Panozzo and others},
-  note = {http://libigl.github.io/libigl/},
+  note = {https://libigl.github.io/libigl/},
   year = {2018},
 }
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: libigl
-site_url: 'http://libigl.github.io/libigl/'
+site_url: 'https://libigl.github.io/libigl/'
 repo_name: 'libigl/libigl'
 repo_url: 'https://github.com/libigl/libigl'
 edit_uri: '../libigl.github.io/edit/docs/docs/'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: libigl
-site_url: 'https://libigl.github.io/libigl/'
+site_url: 'https://libigl.github.io/'
 repo_name: 'libigl/libigl'
 repo_url: 'https://github.com/libigl/libigl'
 edit_uri: '../libigl.github.io/edit/docs/docs/'


### PR DESCRIPTION
No more links to http://libigl.github.io/libigl/
As discussed in #16 
A preview can be inspected at https://www.crashing.systems/libigl.github.io/