### PR TITLE
Fix docs typos

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Before opening an issue on creating a pull request, please check the following:
 
 !!! tip
     
-    - Make sure your read the
+    - Make sure you read the
       [**FAQ**](https://github.com/libigl/libigl/wiki/FAQ) before asking a new
       question, search [**existing
       issues**](https://github.com/libigl/libigl/issues?q=is%3Aissue+is%3Aclosed)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -673,7 +673,7 @@ for(int i : vertices)
   {
     for(int k : triangle_on_edge(i,j))
     {
-      L(i,j) = cot(angle(i,j,k));
+      L(i,j) += cot(angle(i,j,k));
       L(i,i) -= cot(angle(i,j,k));
     }
   }


### PR DESCRIPTION
While reading the tutorial and trying to understand what is a "cotangent Laplacian" I spotted what I think is a minor typo in the first example implementation code snippet.