### PR TITLE
Move 'Downloading Libigl' one level up

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -35,7 +35,7 @@ libigl:
   the function.
 
 
-#### Downloading Libigl
+### Downloading Libigl
 libigl can be downloaded from our [github
 repository](https://github.com/libigl/libigl) or cloned with git:
 


### PR DESCRIPTION
Moving the section one level up ensures that it appears in the sidebar
table of content, making it easier for new users to navigate to the
corresponding section.