### PR TITLE
Update Swept Volume Tutorial to reflect non-copyleft status

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -3734,7 +3734,7 @@ In libigl, if your input solid's surface is represented by `(V,F)` then the
 output surface mesh will be `(SV,SF)` after calling:
 
 ```cpp
-igl::copyleft::swept_volume(V,F,num_time_steps,grid_size,isolevel,SV,SF);
+igl::swept_volume(V,F,num_time_steps,grid_size,isolevel,SV,SF);
 ```
 
 The `isolevel` parameter can be set to zero to approximate the exact swept


### PR DESCRIPTION
As of libigl dbba9ca92, Swept Volume is no longer part of the copyleft part of libigl.  However, the Tutorial was never updated to reflect this change.