### PR TITLE
Persistent C++/Python language toggle (per-symbol)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,6 +44,10 @@ jobs:
             --dox-index docs/dox/files.html \
             --out docs/python/api
 
+      - name: Inject the C++/Python toggle into the Doxygen pages 🔀
+        shell: bash
+        run: python inject_dox_toggle.py docs/dox
+
       - name: Build website 🛠
         shell: bash
         run: mkdocs build

--- a/docs/css/lang-toggle.css
+++ b/docs/css/lang-toggle.css
@@ -1,0 +1,42 @@
+/* C++ / Python language toggle (shared by MkDocs + Doxygen pages). */
+.lang-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  margin: 0 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 1em;
+  overflow: hidden;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1.6;
+  flex-shrink: 0;
+}
+.lang-toggle a {
+  padding: 0.1em 0.7em;
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.85;
+  transition: background-color 0.15s, color 0.15s;
+}
+.lang-toggle a:hover { opacity: 1; }
+.lang-toggle a.lang-toggle__active {
+  background: #ffffff;
+  color: #2196f3;
+  opacity: 1;
+}
+
+/* Inside the MkDocs (Material) header the text is already light. */
+.md-header__inner .lang-toggle { color: var(--md-primary-bg-color, #fff); }
+
+/* Doxygen pages have no header slot: float a pill in the top-right. */
+.lang-toggle--fixed {
+  position: fixed;
+  top: 8px;
+  right: 12px;
+  z-index: 1000;
+  color: #333;
+  background: #2196f3;
+  border-color: #2196f3;
+}
+.lang-toggle--fixed a { color: #fff; }
+.lang-toggle--fixed a.lang-toggle__active { background: #fff; color: #2196f3; }

--- a/docs/js/lang-toggle.js
+++ b/docs/js/lang-toggle.js
@@ -1,0 +1,80 @@
+/*
+ * Persistent C++ / Python language toggle shared by the MkDocs pages and the
+ * Doxygen (/dox/) pages of the libigl site.
+ *
+ * Behaviour: toggling jumps to the *equivalent* page in the other language when
+ * one exists (per symbol), otherwise falls back to that language's reference
+ * home. The mapping is symbol_map.json, generated from the Python bindings.
+ */
+(function () {
+  "use strict";
+
+  var MAP_URL = "/python/api/symbol_map.json";
+  var PY_HOME = "/python/api/";
+  var CPP_HOME = "/dox/index.html";
+
+  // Symbol of the page we are on, or null.
+  function currentSymbol(path, lang) {
+    if (lang === "cpp") {
+      // Doxygen file-reference pages: <name>_8h.html, underscores doubled.
+      var m = path.match(/\/([^\/]+)_8h\.html$/);
+      if (m) return m[1].replace(/__/g, "_").toLowerCase();
+      return null;
+    }
+    if (lang === "py") {
+      var h = (location.hash || "").replace(/^#/, "");
+      return h ? h.toLowerCase() : null;
+    }
+    return null;
+  }
+
+  function currentLang(path) {
+    if (path.indexOf("/dox/") !== -1) return "cpp";
+    if (path.indexOf("/python/") !== -1) return "py";
+    return "cpp"; // the rest of the main site is the C++ side
+  }
+
+  function build(map) {
+    var path = location.pathname;
+    var lang = currentLang(path);
+    var sym = currentSymbol(path, lang);
+    var entry = (sym && map[sym]) || {};
+
+    var here = location.pathname + location.hash;
+    var cppHref = lang === "cpp" ? here : (entry.cpp || CPP_HOME);
+    var pyHref = lang === "py" ? here : (entry.py || PY_HOME);
+
+    var el = document.createElement("div");
+    el.className = "lang-toggle";
+    el.setAttribute("role", "group");
+    el.setAttribute("aria-label", "Documentation language");
+    el.innerHTML =
+      '<a data-lang="cpp"' + (lang === "cpp" ? ' class="lang-toggle__active"' : "") +
+        ' href="' + cppHref + '">C++</a>' +
+      '<a data-lang="py"' + (lang === "py" ? ' class="lang-toggle__active"' : "") +
+        ' href="' + pyHref + '">Python</a>';
+
+    // Prefer to sit inside the Material header; otherwise float (Doxygen).
+    var header = document.querySelector(".md-header__inner");
+    if (header) {
+      var source = header.querySelector(".md-header__source");
+      header.insertBefore(el, source || null);
+    } else {
+      el.className += " lang-toggle--fixed";
+      document.body.appendChild(el);
+    }
+  }
+
+  function init() {
+    fetch(MAP_URL)
+      .then(function (r) { return r.ok ? r.json() : {}; })
+      .catch(function () { return {}; })
+      .then(build);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/generate_python_api.py
+++ b/generate_python_api.py
@@ -20,10 +20,16 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import os
 import re
 from collections import Counter
 from pathlib import Path
+
+
+def slugify(name: str) -> str:
+    """Match python-markdown's default heading anchor slug for a symbol name."""
+    return re.sub(r"[^a-z0-9_]+", "-", name.lower()).strip("-")
 
 DOX_BASE = "https://libigl.github.io/dox"
 
@@ -346,6 +352,9 @@ def main():
                          "target /dox/ site; links are validated against it so "
                          "none 404. Omit to link by header-name heuristic only.")
     ap.add_argument("--out", default="website/docs/api")
+    ap.add_argument("--url-base", default="/python/api",
+                    help="site-root URL under which the API pages are served; "
+                         "used to build the symbol_map.json toggle links")
     args = ap.parse_args()
 
     package = Path(args.package).resolve()
@@ -380,21 +389,35 @@ def main():
 
     stubs = sorted(package.rglob("pyigl_*.pyi"))
     index_rows = []
+    symbol_map = {}  # slug -> {"py": url, "cpp": url} for the C++/Python toggle
+
+    def record(name, stem):
+        entry = symbol_map.setdefault(slugify(name), {})
+        entry["py"] = f"{args.url_base}/{stem}/#{slugify(name)}"
+        if name in linkable:
+            entry["cpp"] = f"/dox/{linkable[name]}"
+
     for stub in stubs:
         module = module_for(stub, package_parent)
         title = MODULE_TITLES.get(module, module)
         functions, classes = collect(stub)
+        stem = module.replace(".", "_")
         page = [f"# {title}\n"]
         page.append(f"Python API reference for `{module}`.\n")
         for name in sorted(functions):
             page.append(emit_function(name, functions[name], linkable))
+            record(name, stem)
         for node, methods, doc in sorted(classes, key=lambda c: c[0].name):
             page.append(emit_class(node, methods, doc, linkable))
-        fname = module.replace(".", "_") + ".md"
+            record(node.name, stem)
+        fname = stem + ".md"
         (out / fname).write_text("\n".join(page))
         n = len(functions) + len(classes)
         index_rows.append((title, fname, n))
         print(f"  {module}: {len(functions)} functions, {len(classes)} classes -> {fname}")
+
+    (out / "symbol_map.json").write_text(json.dumps(symbol_map, sort_keys=True))
+    print(f"  wrote symbol_map.json ({len(symbol_map)} symbols)")
 
     # An index page listing every module.
     idx = ["# API Reference\n",

--- a/inject_dox_toggle.py
+++ b/inject_dox_toggle.py
@@ -1,0 +1,32 @@
+"""Inject the shared C++/Python language toggle into generated Doxygen pages.
+
+Doxygen output has no hook for our toggle, so after `doxygen` runs we add a
+stylesheet <link> and the toggle <script> to every generated page. Both use
+site-root-absolute URLs, served by MkDocs from docs/css and docs/js.
+
+Usage: python inject_dox_toggle.py docs/dox
+"""
+import sys
+from pathlib import Path
+
+HEAD = '<link rel="stylesheet" href="/css/lang-toggle.css">'
+BODY = '<script src="/js/lang-toggle.js"></script>'
+
+
+def main(root):
+    n = 0
+    for f in Path(root).rglob("*.html"):
+        t = f.read_text(errors="ignore")
+        if "lang-toggle.js" in t:
+            continue
+        if "</head>" in t:
+            t = t.replace("</head>", HEAD + "\n</head>", 1)
+        if "</body>" in t:
+            t = t.replace("</body>", BODY + "\n</body>", 1)
+        f.write_text(t)
+        n += 1
+    print(f"injected language toggle into {n} Doxygen pages")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "docs/dox")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,9 +22,11 @@ extra:
   repo_url: 'https://github.com/libigl/libigl/tree/main'
 extra_javascript:
   - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'
+  - 'js/lang-toggle.js'
 extra_css:
   - 'css/style.css'
   - 'css/pygments.css'
+  - 'css/lang-toggle.css'
 markdown_extensions:
   - codehilite:
       guess_lang: false


### PR DESCRIPTION
Adds a **C++ | Python** switch to the site header (and to the Doxygen pages) that jumps to the **equivalent page in the other language when one exists**, and otherwise falls back to that language's reference home. This is the "better than Polyscope" behavior requested — a per-symbol toggle, not a landing-page switch.

## How it works
- **`generate_python_api.py`** now also emits **`symbol_map.json`**: `slug → {py, cpp}` URLs for every bound symbol (the `cpp` side only when the Doxygen page is unambiguous and exists, reusing the same validation as the cross-links).
- **`docs/js/lang-toggle.js`** (shared, + `docs/css/lang-toggle.css`) derives the current symbol from the URL — the Doxygen `‹name›_8h.html` filename, or the Python page's `#anchor` — looks up the counterpart in `symbol_map.json`, and navigates. Wired into MkDocs via `extra_javascript`/`extra_css`, so it renders in the Material header on every page.
- **`inject_dox_toggle.py`** adds the same CSS/JS to every generated Doxygen page; `gh-pages.yml` runs it right after doxygen. **No change to the `libigl/libigl` repo** is needed.

## Behavior (verified against the real symbol map)
| On page | C++ button | Python button |
| --- | --- | --- |
| `/dox/cotmatrix_8h.html` | (here) | `/python/api/igl/#cotmatrix` |
| `/python/api/igl/#cotmatrix` | `/dox/cotmatrix_8h.html` | (here) |
| `/dox/AABB_8h.html` | (here) | `/python/api/igl/#aabb` |
| `/python/api/igl/#marching_cubes` (no unambiguous C++) | `/dox/index.html` (home) | (here) |
| `/` or `/tutorial/` | (here) | `/python/api/` (home) |

## Previewing
Previewing this correctly needs the full CI build: the Doxygen-side toggle is injected during the `doxygen` step, and the toggle uses site-root-absolute URLs (so it must be served at the site root, not a subpath). The change is additive (a JS widget) and easily reverted, so merging to `docs` is the simplest way to see it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)